### PR TITLE
Update to 1.1.3

### DIFF
--- a/addons/amxmodx/configs/rt_configs/rt_effects.cfg
+++ b/addons/amxmodx/configs/rt_configs/rt_effects.cfg
@@ -12,16 +12,6 @@ rt_spectator "1"
 // Maximum: "1"
 rt_notify_dhud "1"
 
-// Цвет трупа, который воскрешают(HEX)
-// The color of the corpse being resurrected(HEX)
-// Default: "#5da130"
-rt_revive_glow "#5da130"
-
-// Цвет трупа, который минируют(HEX)
-// The color of the corpse being planted(HEX)
-// Default: "#9b2d30"
-rt_planting_glow "#9b2d30"
-
 // Спрайт воскрешения над трупом. Чтобы отключить эту функцию, оставьте cvar пустым
 // Resurrection sprite over a corpse. To disable the function, leave the cvar empty
 // Default: "sprites/rt/corpse_sprite2.spr"

--- a/addons/amxmodx/scripting/include/rt_api.inc
+++ b/addons/amxmodx/scripting/include/rt_api.inc
@@ -7,7 +7,7 @@
 #endif
 #define _rt_api_included
 
-#define VERSION "1.1.2"
+#define VERSION "1.1.3"
 #define AUTHORS "ufame & Albertio"
 
 enum modes_struct

--- a/addons/amxmodx/scripting/rt_core.sma
+++ b/addons/amxmodx/scripting/rt_core.sma
@@ -303,7 +303,6 @@ public MessageHook_ClCorpse()
 
 	enum
 	{
-		arg_model = 1,
 		arg_body = 10,
 		arg_id = 12
 	};
@@ -316,15 +315,6 @@ public MessageHook_ClCorpse()
 
 	if(iPlTeam == TEAM_SPECTATOR)
 		return PLUGIN_HANDLED;
-
-	static szTemp[MAX_RESOURCE_PATH_LENGTH], szModel[MAX_RESOURCE_PATH_LENGTH];
-	get_msg_arg_string(arg_model, szTemp, charsmax(szTemp));
-	formatex(szModel, charsmax(szModel), "models/player/%s/%s.mdl", szTemp, szTemp);
-
-	if(!file_exists(szModel)) {
-		//abort(AMX_ERR_GENERAL, "Can't find '%s'", szModel)
-		return PLUGIN_HANDLED;
-	}
 
 	static iEnt;
 	iEnt = rg_create_entity("info_target");
@@ -343,7 +333,13 @@ public MessageHook_ClCorpse()
 		return PLUGIN_HANDLED;
 	}
 
-	engfunc(EngFunc_SetModel, iEnt, szModel);
+	static szModel[MAX_RESOURCE_PATH_LENGTH];
+
+	set_entvar(iEnt, var_modelindex, get_entvar(iPlayer, var_modelindex));
+	get_entvar(iPlayer, var_model, szModel, charsmax(szModel));
+	set_entvar(iEnt, var_model, szModel);
+	set_entvar(iEnt, var_renderfx, kRenderFxDeadPlayer);
+	set_entvar(iEnt, var_renderamt, float(iPlayer));
 
 	set_entvar(iEnt, var_classname, DEAD_BODY_CLASSNAME);
 	set_entvar(iEnt, var_body, get_msg_arg_int(arg_body));

--- a/addons/amxmodx/scripting/rt_effects.sma
+++ b/addons/amxmodx/scripting/rt_effects.sma
@@ -7,21 +7,21 @@ enum CVARS
 {
 	SPECTATOR,
 	NOTIFY_DHUD,
-	REVIVE_GLOW[32],
-	PLANTING_GLOW[32],
+	//REVIVE_GLOW[32],
+	//PLANTING_GLOW[32],
 	CORPSE_SPRITE[64],
 	Float:SPRITE_SCALE
 };
 
 new g_eCvars[CVARS];
 
-enum GlowColors
+/*enum GlowColors
 {
 	Float:REVIVE_COLOR,
 	Float:PLANTING_COLOR
 };
 
-new Float:g_eGlowColors[GlowColors][3];
+new Float:g_eGlowColors[GlowColors][3];*/
 
 new const CORPSE_SPRITE_CLASSNAME[] = "rt_corpse_sprite";
 
@@ -47,11 +47,11 @@ public plugin_init()
 
 public plugin_cfg()
 {
-	if(g_eCvars[REVIVE_GLOW][0] != EOS)
+	/*if(g_eCvars[REVIVE_GLOW][0] != EOS)
 		g_eGlowColors[REVIVE_COLOR] = parseHEXColor(g_eCvars[REVIVE_GLOW]);
-	
+
 	if(g_eCvars[PLANTING_GLOW][0] != EOS)
-		g_eGlowColors[PLANTING_COLOR] = parseHEXColor(g_eCvars[PLANTING_GLOW]);
+		g_eGlowColors[PLANTING_COLOR] = parseHEXColor(g_eCvars[PLANTING_GLOW]);*/
 
 	g_fTime = get_pcvar_float(get_cvar_pointer("rt_revive_time"));
 }
@@ -86,17 +86,17 @@ public rt_revive_start(const iEnt, const id, const iActivator, const modes_struc
 				DisplayDHUDMessage(iActivator, fmt("%L", iActivator, "RT_DHUD_REVIVE", id), eMode);
 				DisplayDHUDMessage(id, fmt("%L %L", id, "RT_CHAT_TAG", id, "RT_DHUD_REVIVE2", iActivator), eMode);
 			}
-			
-			if(g_eCvars[REVIVE_GLOW][0] != EOS)
-				rg_set_rendering(iEnt, kRenderFxGlowShell, g_eGlowColors[REVIVE_COLOR], kRenderNormal, 30.0);
+
+			/*if(g_eCvars[REVIVE_GLOW][0] != EOS)
+				rg_set_rendering(iEnt, kRenderFxGlowShell, g_eGlowColors[REVIVE_COLOR], kRenderNormal, 30.0);*/
 		}
 		case MODE_PLANT:
 		{
 			if(g_eCvars[NOTIFY_DHUD])
 				DisplayDHUDMessage(iActivator, fmt("%L", iActivator, "RT_DHUD_PLANTING", id), eMode);
-			
-			if(g_eCvars[PLANTING_GLOW][0] != EOS)
-				rg_set_rendering(iEnt, kRenderFxGlowShell, g_eGlowColors[PLANTING_COLOR], kRenderNormal, 30.0);
+
+			/*if(g_eCvars[PLANTING_GLOW][0] != EOS)
+				rg_set_rendering(iEnt, kRenderFxGlowShell, g_eGlowColors[PLANTING_COLOR], kRenderNormal, 30.0);*/
 		}
 	}
 
@@ -105,7 +105,7 @@ public rt_revive_start(const iEnt, const id, const iActivator, const modes_struc
 
 public rt_revive_cancelled(const iEnt, const id, const iActivator, const modes_struct:eMode)
 {
-	switch(eMode)
+	/*switch(eMode)
 	{
 		case MODE_REVIVE:
 		{
@@ -117,7 +117,7 @@ public rt_revive_cancelled(const iEnt, const id, const iActivator, const modes_s
 			if(g_eCvars[PLANTING_GLOW][0] != EOS)
 				rg_set_rendering(iEnt);
 		}
-	}
+	}*/
 
 	if(g_eCvars[NOTIFY_DHUD])
 	{
@@ -131,13 +131,13 @@ public rt_revive_cancelled(const iEnt, const id, const iActivator, const modes_s
 
 public rt_revive_end(const iEnt, const id, const iActivator, const modes_struct:eMode)
 {
-	switch(eMode)
+	/*switch(eMode)
 	{
 		case MODE_REVIVE:
 		{
 			static modes_struct:iMode;
 			iMode = get_entvar(iEnt, var_iuser3);
-			
+
 			if(iMode != MODE_PLANT && g_eCvars[REVIVE_GLOW][0] != EOS)
 				rg_set_rendering(iEnt);
 		}
@@ -146,7 +146,7 @@ public rt_revive_end(const iEnt, const id, const iActivator, const modes_struct:
 			if(g_eCvars[PLANTING_GLOW][0] != EOS)
 				rg_set_rendering(iEnt);
 		}
-	}
+	}*/
 
 	if(g_eCvars[NOTIFY_DHUD])
 	{
@@ -277,7 +277,7 @@ public RegisterCvars()
 		1.0),
 		g_eCvars[NOTIFY_DHUD]
 	);
-	bind_pcvar_string(create_cvar(
+	/*bind_pcvar_string(create_cvar(
 		"rt_revive_glow",
 		"#5da130",
 		FCVAR_NONE,
@@ -292,7 +292,7 @@ public RegisterCvars()
 		"The color of the corpse being planted(HEX)"),
 		g_eCvars[PLANTING_GLOW],
 		charsmax(g_eCvars[PLANTING_GLOW])
-	);
+	);*/
 	bind_pcvar_string(create_cvar(
 		"rt_corpse_sprite",
 		"sprites/rt/corpse_sprite2.spr",


### PR DESCRIPTION
Improving attack protection logic (thanks Garey)
Added simple and effective support for client cvar 'cl_minmodels' (thanks Garey)
The 'rt_revive_glow' and 'rt_planting_glow' cvars have been removed due to conflict with 'cl_minmodels' support method